### PR TITLE
Update cgi.js to catch invalid headers

### DIFF
--- a/cgi.js
+++ b/cgi.js
@@ -129,9 +129,14 @@ function cgi(cgiBin, options) {
           // Don't set the 'Status' header. It's special, and should be
           // used to set the HTTP response code below.
           if (header.key === 'Status') return;
-          res.setHeader(header.key, header.value);
+          try {
+            res.setHeader(header.key, header.value);
+            throw err
+          } catch (err) {
+            // handle the error safely
+            console.error(err, header.key, header.value)
+          }
         });
-
         // set the response status code
         res.statusCode = parseInt(headers.status, 10) || 200;
 


### PR DESCRIPTION
Added try\catch to res.setHeader to catch invalid headers without crashing. 
Updating to Node 5.10.1 produced crashes with invalid headers in application that was previously working. The actual problem may be deeper in the header-stack and it's converting the stream into a header object or the actual cgi. Both of which are way outside my comfort zone. So a simple try\catch which fixes the crash as I am not using the returned headers anyway.

For info here is my header object

[ 'Content-type': 'text/html\nPragma: no-cache\nSet-Cookie: w3ProfileId=177855568321671; expires=Saturday, 9-Sep-2017 23:59:59 GMT;' ]

My guess is that it all goes wrong with the forward slash in text/html and from there the closing single quote is missing. This makes the whole headers a single string.
