### PR TITLE
Updated cgi.js with try\catch to stop crash on invalid headers

### DIFF
--- a/cgi.js
+++ b/cgi.js
@@ -131,7 +131,7 @@ function cgi(cgiBin, options) {
           if (header.key === 'Status') return;
           try {
             res.setHeader(header.key, header.value);
-            throw err
+            var err = new Error('Set Header Failed');
           } catch (err) {
             // handle the error safely
             console.error(err, header.key, header.value)


### PR DESCRIPTION
NodeJS 5.10.1. Headers from buffer stream not being parsed correctly causing a crash when trying to set them for the response object.
Try\Catch added to prevent this.
The problem comes from header-stack, working on a pull request for that to parse the headers correctly.
This error may be unique to my cgi however this fix should not break any other implementations.
